### PR TITLE
Disabled crons triggered by preview bots and crawlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 var mustacheExpress = require('mustache-express');
 const axios = require ('axios');
+const isbot = require('isbot');
 const app = express()
 const port = 3000
 
@@ -11,7 +12,7 @@ app.set('views', __dirname + '/views');
 var active = 0;
 
 app.get('/', (req, res) => {
-	if(req.query.time && req.query.url){
+	if(req.query.time && req.query.url && !isbot(req.headers["user-agent"])){
 		active+=1;
 		setTimeout(function(){
 		axios.get(decodeURIComponent(req.query.url))

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^0.18.0",
     "express": "^4.16.4",
+    "isbot": "^2.4.0",
     "mustache-express": "^1.2.8"
   }
 }


### PR DESCRIPTION
When you post a URL on Twitter or other platforms, they create a GET request to fetch a preview card. 

GET requests on kron.fun creates duplicate crons due to crawlers. 